### PR TITLE
can be compiled for cmake versions < 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ set(PKGNAME torchnet)
 file(GLOB_RECURSE luafiles RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.lua")
 
 foreach(file ${luafiles})
-  get_filename_component(dir ${file} DIRECTORY)
+  get_filename_component(dir ${file} PATH)
   install(FILES ${file} DESTINATION ${LUA_PATH}/${PKGNAME}/${dir})
 endforeach()


### PR DESCRIPTION
DIRECTORY syntax was added in CMake 2.8.12
PATH = Legacy alias for DIRECTORY (use for CMake <= 2.8.11)
ref: https://cmake.org/cmake/help/v3.0/command/get_filename_component.html

Error information when cmake versions < 2.8.12:
CMake Error at CMakeLists.txt:9 (get_filename_component):
  get_filename_component unknown component DIRECTORY