### PR TITLE
[engine] Added new states to the optim and sgd engines

### DIFF
--- a/engine/optimengine.lua
+++ b/engine/optimengine.lua
@@ -76,7 +76,8 @@ OptimEngine.train = argcheck{
             config = config or {},
             optim = optimState or {},
             epoch = 0, -- epoch done so far
-            t = 0 -- samples seen so far
+            t = 0, -- samples seen so far
+            training = true
          }
 
          if paramFun then

--- a/engine/sgdengine.lua
+++ b/engine/sgdengine.lua
@@ -66,7 +66,8 @@ SGDEngine.train = argcheck{
             maxepoch = maxepoch,
             sample = {},
             epoch = 0, -- epoch done so far
-            t = 0 -- samples seen so far
+            t = 0, -- samples seen so far
+            training = true
          }
 
          self.hooks("onStart", state)
@@ -122,7 +123,8 @@ SGDEngine.test = argcheck{
          iterator = iterator,
          criterion = criterion,
          sample = {},
-         t = 0 -- samples seen so far
+         t = 0, -- samples seen so far
+         training = false
       }
 
       self.hooks("onStart", state)


### PR DESCRIPTION
There are a few hooks that are shared by both train() and test().
This change adds a state called `training` which is true in train()
and false in test(). This will allow users to alter behavior based
on the function being run in an elegant manner.

When I want a hook to perform differently during `test()` and `train()` phases, I am currently checking for existence of things like `state.lr` etc. Adding a state to indicate the phase will make the client code more readable .. `if (state.training) ... else ... end`.