### PR TITLE
Added support for knowing number of batches processed so far

### DIFF
--- a/engine/optimengine.lua
+++ b/engine/optimengine.lua
@@ -77,6 +77,7 @@ OptimEngine.train = argcheck{
             optim = optimState or {},
             epoch = 0, -- epoch done so far
             t = 0, -- samples seen so far
+            numbatches = 0, -- number of batches processed in an epoch so far
             training = true
          }
 
@@ -95,6 +96,7 @@ OptimEngine.train = argcheck{
             state.network:training()
 
             self.hooks("onStartEpoch", state)
+            state.numbatches = 0
             for sample in state.iterator() do
                state.sample = sample
                self.hooks("onSample", state)
@@ -116,6 +118,7 @@ OptimEngine.train = argcheck{
 
                state.optimMethod(feval, state.params, state.config, state.optim)
                state.t = state.t + 1
+               state.numbatches = state.numbatches + 1
                self.hooks("onUpdate", state)
             end
             state.epoch = state.epoch + 1

--- a/engine/sgdengine.lua
+++ b/engine/sgdengine.lua
@@ -67,6 +67,7 @@ SGDEngine.train = argcheck{
             sample = {},
             epoch = 0, -- epoch done so far
             t = 0, -- samples seen so far
+            numbatches = 0, -- number of batches processed in an epoch so far
             training = true
          }
 
@@ -75,6 +76,7 @@ SGDEngine.train = argcheck{
             state.network:training()
 
             self.hooks("onStartEpoch", state)
+            state.numbatches = 0
             for sample in state.iterator() do
                state.sample = sample
                self.hooks("onSample", state)
@@ -103,6 +105,7 @@ SGDEngine.train = argcheck{
                   state.network:updateParameters(state.lr)
                end
                state.t = state.t + 1
+               state.numbatches = state.numbatches + 1
                self.hooks("onUpdate", state)
             end
             state.epoch = state.epoch + 1


### PR DESCRIPTION
Currently in the state, we have ability to check number of updates done to the model, but nothing to check how many batches have been processed in an epoch so far. This is required to measure progress in an epoch and hence a really useful state to have.