### PR TITLE
Fix IndexedDataset mmap&mmapidx=false

### DIFF
--- a/dataset/indexeddataset.lua
+++ b/dataset/indexeddataset.lua
@@ -147,6 +147,7 @@ local function readindex(self, indexfilename)
    for typename, type in pairs(IndexedDatasetIndexTypes) do
       if type.code == code then
          self.type = type
+         self.typename = typename
       end
    end
    assert(self.type, "unrecognized type")


### PR DESCRIPTION
Please try this code :

```lua
local tnt = require 'torchnet'
local os = require 'os'
local mnist = require 'mnist'

local function writeDataset(mode)
   local dataname = mode..'dataset'
   local pathdata = 'example/'..dataname
   os.execute('mkdir -p '..pathdata)

   local dataset = mnist[dataname]()
   dataset.data = dataset.data:reshape(dataset.data:size(1),
      dataset.data:size(2) * dataset.data:size(3)):float()

   local inputwriter = tnt.IndexedDatasetWriter{
      indexfilename = pathdata..'/input.idx',
      datafilename  = pathdata..'/input.bin',
      type          = 'float'
   }
   local targetwriter = tnt.IndexedDatasetWriter{
      indexfilename = pathdata..'/target.idx',
      datafilename  = pathdata..'/target.bin',
      type          = 'byte'
   }
   for i=1, dataset.size do
      inputwriter:add(dataset.data[i])
      targetwriter:add(torch.ByteTensor{dataset.label[i] + 1})
   end
   inputwriter:close()
   targetwriter:close()
end

writeDataset('test')

local dataset = tnt.IndexedDataset{
   fields  = {
      'input',
      'target'
   },
   path    = 'example/testdataset',
   mmap    = true,
   mmapidx = false
}

local dataset = tnt.IndexedDataset{
   fields  = {
      'input',
      'target'
   },
   path    = 'example/testdataset',
   mmap    = true,
   mmapidx = true
}

local dataset = tnt.IndexedDataset{
   fields  = {
      'input',
      'target'
   },
   path    = 'example/testdataset',
   mmap    = false,
   mmapidx = true
}

-- Error : ...nstall/share/lua/5.1/torchnet/dataset/indexeddataset.lua:367:
--            attempt to index field 'type' (a nil value)
local dataset = tnt.IndexedDataset{
   fields  = {
      'input',
      'target'
   },
   path    = 'example/testdataset',
   mmap    = false,
   mmapidx = false
}
```

This commit will fix it.