### PR TITLE
Lua 5.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 sudo: false
 env:
   - TORCH_LUA_VERSION=LUAJIT21
+  - TORCH_LUA_VERSION=LUA52
 addons:
   apt:
     packages:

--- a/dataset/paralleldatasetiterator.lua
+++ b/dataset/paralleldatasetiterator.lua
@@ -104,17 +104,16 @@ on which `tnt.ParallelDatasetIterator` relies.
             local function enqueue()
                while idx <= size and threads:acceptsjob() do
                   threads:addjob(
-                     function(argList)
-                        local origIdx, idx = unpack(argList)
+                     function(origIdx, idx)
                         local sample = gdataset:get(idx)
                         collectgarbage()
                         collectgarbage()
-                        return {sample, origIdx}
+                        return sample, origIdx
                      end,
-                     function(argList)
-                        sample, sampleOrigIdx = unpack(argList)
+                     function(_sample_, _origIdx_)
+                        sample, sampleOrigIdx = _sample_, _origIdx_
                      end,
-                     {idx, perm(idx)}
+                     idx, perm(idx)
                   )
                   idx = idx + 1
                end


### PR DESCRIPTION
Lua 5.2 has table.unpack instead of unpack, but it's not necessary because threads:addjob() supports multiple arguments and return values