### PR TITLE
Explicitly install torch before building torchnet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ before_script:
 - make && make install
 - cd $ROOT_TRAVIS_DIR
 - export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH
+- ${INSTALL_PREFIX}/bin/luarocks install torch
 script:
 - ${INSTALL_PREFIX}/bin/luarocks make rocks/torchnet-scm-1.rockspec
 - export PATH=${INSTALL_PREFIX}/bin:$PATH


### PR DESCRIPTION
Fixes the travis build.

Torchnet depends on torch and tds. The tds package only optionally
depends on torch; if torch isn't present, tds will be built without
torch support. Install torch first to ensure that tds is built with
torch support.