### PR TITLE
Make self.__partition Tensor

### DIFF
--- a/dataset/splitdataset.lua
+++ b/dataset/splitdataset.lua
@@ -112,8 +112,13 @@ by the `get()` method.
    {name='partition', type='string'},
    call =
       function(self, partition)
-         self.__partition = self.__names[partition]
-         if not self.__partition then error('partition not found') end
+         local id = self.__names[partition]
+         if not id then error('partition not found') end
+         if self.__partition then
+            self.__partition[1] = id
+         else
+            self.__partition = torch.LongTensor{id}
+         end
       end
 }
 
@@ -122,7 +127,7 @@ SplitDataset.size = argcheck{
    call =
       function(self)
          assert(self.__partition, 'select a partition before accessing data')
-         return self.__partitionsizes[self.__partition]
+         return self.__partitionsizes[self.__partition[1]]
       end
 }
 
@@ -133,8 +138,8 @@ SplitDataset.get = argcheck{
       function(self, idx)
          assert(self.__partition, 'select a partition before accessing data')
          assert(idx >= 1 and idx <= self:size(), 'index out of bounds')
-         local offset = (self.__partition == 1) and 0 or
-            self.__partitionsizes:narrow(1, 1, self.__partition - 1):sum()
+         local offset = (self.__partition[1] == 1) and 0 or
+            self.__partitionsizes:narrow(1, 1, self.__partition[1] - 1):sum()
          return self.__dataset:get(offset + idx)
       end
 }


### PR DESCRIPTION
Allows splitDataset to be used with ParallelDatasetIterator

Test (gives same output in both cases currently, which it should not)

```lua
local tnt = require 'torchnet'
local tbl = tnt.ListDataset{
   list = torch.LongTensor{1,2,3,4,5,6,7,8,9,10},
   load = function(x) return {x} end
}
local d = tnt.SplitDataset(tbl, {train=4, val=6},'train')
local iter = tnt.ParallelDatasetIterator{
   nthread = 4,
   init = function() require 'torchnet' end,
   closure = function() return d:batch(4) end,
   ordered = true
}
d:select('train')
for x in iter() do print(x) end
d:select('val')
for x in iter() do print(x) end
```