### PR TITLE
Setting 'epoch' parameter of 'state' from the arguments of 'engine:train()'

### DIFF
--- a/engine/optimengine.lua
+++ b/engine/optimengine.lua
@@ -59,23 +59,24 @@ OptimEngine.train = argcheck{
    {name="criterion", type="nn.Criterion"},
    {name="iterator", type="tnt.DatasetIterator"},
    {name="maxepoch", type="number", default=1000},
+   {name="epoch", type="number", default=0},}
    {name="optimMethod", type="function"},
    {name="config", type="table", opt=true},
    {name="optimState", type="table", opt=true},
    {name="paramFun", type="function", opt=true},
    call =
-      function(self, network, criterion, iterator, maxepoch, optimMethod,
+      function(self, network, criterion, iterator, maxepoch, epoch, optimMethod,
                 config, optimState, paramFun)
          local state = {
             network = network,
             criterion = criterion,
             iterator = iterator,
             maxepoch = maxepoch,
+            epoch = epoch, -- epoch done so far
             optimMethod = optimMethod,
             sample = {},
             config = config or {},
             optim = optimState or {},
-            epoch = 0, -- epoch done so far
             t = 0, -- samples seen so far
             training = true
          }

--- a/engine/optimengine.lua
+++ b/engine/optimengine.lua
@@ -59,7 +59,7 @@ OptimEngine.train = argcheck{
    {name="criterion", type="nn.Criterion"},
    {name="iterator", type="tnt.DatasetIterator"},
    {name="maxepoch", type="number", default=1000},
-   {name="epoch", type="number", default=0},}
+   {name="epoch", type="number", default=0},
    {name="optimMethod", type="function"},
    {name="config", type="table", opt=true},
    {name="optimState", type="table", opt=true},

--- a/engine/sgdengine.lua
+++ b/engine/sgdengine.lua
@@ -63,7 +63,7 @@ state = {
    ['lrcriterion'] = lrcriterion,
    ['maxepoch']    = maxepoch,
    ['sample']      = {},
-   ['epoch']       = 0, -- epoch done so far
+   ['epoch']       = epoch, -- epoch done so far
    ['t']           = 0, -- samples seen so far
    ['training']    = true
 }
@@ -95,8 +95,9 @@ SGDEngine.train = argcheck{
    {name="lr", type="number"},
    {name="lrcriterion", type="number", defaulta="lr"},
    {name="maxepoch", type="number", default=1000},
+   {name="epoch", type="number", default=0},
    call =
-      function(self, network, criterion, iterator, lr, lrcriterion, maxepoch)
+      function(self, network, criterion, iterator, lr, lrcriterion, maxepoch, epoch)
          local state = {
             network = network,
             criterion = criterion,
@@ -105,7 +106,7 @@ SGDEngine.train = argcheck{
             lrcriterion = lrcriterion,
             maxepoch = maxepoch,
             sample = {},
-            epoch = 0, -- epoch done so far
+            epoch = epoch, -- epoch done so far
             t = 0, -- samples seen so far
             training = true
          }


### PR DESCRIPTION
Providing a way for 'epoch' parameter initialization. It is quite handy for network fine-tuning.